### PR TITLE
Don't execute downstream if parent jobs are enqueued.

### DIFF
--- a/src/main/java/org/lonkar/jobfanin/FanInReverseBuildTrigger.java
+++ b/src/main/java/org/lonkar/jobfanin/FanInReverseBuildTrigger.java
@@ -217,7 +217,7 @@ public final class FanInReverseBuildTrigger extends Trigger<Job> implements Depe
 	 * @return true of stable and not building
 	 */
 	private boolean isNotBuildingAndStable(Job job) {
-		if (!job.isBuilding()) {
+		if (!job.isBuilding() && !job.isInQueue()) {
 			Result result = job.getLastBuild().getResult();
 			if (result != null && result.isBetterOrEqualTo(threshold)) {
 				return true;


### PR DESCRIPTION
I'm having some issues with a race condition where dependent jobs will fail because upstream are enqueued. I was not able to build/test effectively (deps) but the method exists in the doc so I imagine it works as expected `http://javadoc.jenkins-ci.org/hudson/model/Job.html`

What happens is I have 10s of Init jobs that kicks off up to 10 directly dependant jobs each morning at the same time. Obviously that's a large fanout, so they sit in the queue. Those dependant jobs are "faned-in" to a collection job (same number as inits) which requires that all prior jobs have run _for that day_. Unfortunately, because the plugin doesn't currently support queued jobs, a child job will kick off its collector even though a sibiling is sitting in the queue.
