### PR TITLE
JENKINS-38267 - UI always shows default configuration

### DIFF
--- a/src/main/java/org/lonkar/jobfanin/FanInReverseBuildTrigger.java
+++ b/src/main/java/org/lonkar/jobfanin/FanInReverseBuildTrigger.java
@@ -81,6 +81,14 @@ public final class FanInReverseBuildTrigger extends Trigger<Job> implements Depe
 	public String getUpstreamProjects() {
 		return upstreamProjects;
 	}
+	
+	public Result getThreshold() {
+		return threshold;
+	}
+	
+	public boolean isWatchUpstreamRecursively() {
+		return watchUpstreamRecursively;
+	}
 
 	private boolean shouldTrigger(Run upstreamBuild, TaskListener listener) {
 		Jenkins jenkins = Jenkins.getInstance();

--- a/src/main/resources/org/lonkar/jobfanin/FanInReverseBuildTrigger/config.jelly
+++ b/src/main/resources/org/lonkar/jobfanin/FanInReverseBuildTrigger/config.jelly
@@ -29,7 +29,7 @@ THE SOFTWARE.
         <f:textbox autoCompleteDelimChar=","/>
     </f:entry>
     <f:entry title="Watch upstream projects recursively" field="watchUpstreamRecursively" >
-	  <f:checkbox checked="true"/>
+	  <f:checkbox checked="${instance.watchUpstreamRecursively}"/>
 	</f:entry>
 	<f:entry title="">
         <f:radio name="threshold" checked="${instance.threshold==null || instance.threshold.toString()=='SUCCESS'}"


### PR DESCRIPTION
We've also ran into https://issues.jenkins-ci.org/browse/JENKINS-38267. 

Basically the UI always shows "Trigger only if build is stable" regardless of what the user configured. The same holds true for "Watch upstream projects recursively" this option was hard-coded in the UI to true/checked. This PR fixes both issues.
